### PR TITLE
Notification dismissed after action button triggered

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -322,12 +322,12 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         /*
          * Notification add actions
          */
-        createActions(extras, mBuilder, resources, packageName);
+        createActions(extras, mBuilder, resources, packageName, notId);
 
         mNotificationManager.notify(appName, notId, mBuilder.build());
     }
 
-    private void createActions(Bundle extras, NotificationCompat.Builder mBuilder, Resources resources, String packageName) {
+    private void createActions(Bundle extras, NotificationCompat.Builder mBuilder, Resources resources, String packageName, int notId) {
         Log.d(LOG_TAG, "create actions");
         String actions = extras.getString(ACTIONS);
         if (actions != null) {
@@ -345,12 +345,14 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
                         intent.putExtra(CALLBACK, action.getString(CALLBACK));
                         intent.putExtra(PUSH_BUNDLE, extras);
                         intent.putExtra(FOREGROUND, foreground);
+                        intent.putExtra(NOT_ID, notId);
                         pIntent = PendingIntent.getActivity(this, i, intent, PendingIntent.FLAG_UPDATE_CURRENT);
                     } else {
                         intent = new Intent(this, BackgroundActionButtonHandler.class);
                         intent.putExtra(CALLBACK, action.getString(CALLBACK));
                         intent.putExtra(PUSH_BUNDLE, extras);
                         intent.putExtra(FOREGROUND, foreground);
+                        intent.putExtra(NOT_ID, notId);
                         pIntent = PendingIntent.getBroadcast(this, i, intent, PendingIntent.FLAG_UPDATE_CURRENT);
                     }
 


### PR DESCRIPTION
When the user application was closed (e.g., after it's been swiped left), and when a new notification arrived, the notification icon wasn't dismissed when an action button was clicked.
